### PR TITLE
Pin the url of the tested Dockerfile

### DIFF
--- a/src/test_package_cachi2/main.py
+++ b/src/test_package_cachi2/main.py
@@ -10,8 +10,7 @@ from dockerfile_parse import DockerfileParser
 
 if __name__ == '__main__':
     dfp = DockerfileParser(fileobj=io.BytesIO())
-    containerfile_url = ("https://raw.githubusercontent.com/containerbuildsystem/"
-                         "cachi2/main/Containerfile")
+    containerfile_url = "https://raw.githubusercontent.com/containerbuildsystem/cachi2/e793f7c1c446994a353769a89c8395a3ed0639bc/Containerfile"
     r = requests.get(containerfile_url, allow_redirects=True)
     dfp.content = r.content
 


### PR DESCRIPTION
Previously, the script downloaded the Dockerfile from the cachi2 'main' branch. The output would change every time we changed the parent image.

Pin the url to a specific commit to make sure the output stays the same.