### PR TITLE
devfile: add kube inline component

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -7,7 +7,46 @@ metadata:
 components:
   - name: outerloop-build
     image:
-      imageName: pipe-e2e-test:latest
+      imageName: pip-e2e-test:latest
       dockerfile:
         uri: Dockerfile
         buildContext: .
+  - name: outerloop-deploy
+    kubernetes:
+      inlined: |-
+        kind: Deployment
+        apiVersion: apps/v1
+        metadata:
+          name: pip-e2e-test
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: pip-e2e-test
+          template:
+            metadata:
+              labels:
+                app: pip-e2e-test
+            spec:
+              containers:
+                - name: pip-e2e-test
+                  image: pip-e2e-test:latest
+                  resources:
+                    limits:
+                      memory: "1024Mi"
+                      cpu: "500m"
+commands:
+  - id: build-image
+    apply:
+      component: outerloop-build
+  - id: deployk8s
+    apply:
+      component: outerloop-deploy
+  - id: deploy
+    composite:
+      commands:
+        - build-image
+        - deployk8s
+      group:
+        kind: deploy
+        isDefault: true


### PR DESCRIPTION
Add kube line component to ensure the devfile is a valid outerloop definition for the e2e test. See detailed discussion: https://redhat-internal.slack.com/archives/C02HZRGKDEY/p1680778911884259